### PR TITLE
Switch from `python-coveralls` to `coveralls`

### DIFF
--- a/environment_dpl.yml
+++ b/environment_dpl.yml
@@ -7,5 +7,5 @@ dependencies:
   - pip==18.1
   - wheel==0.32.2
   - coverage==4.5.2
-  - python-coveralls==2.9.1
+  - coveralls==1.5.0
   - cython==0.29


### PR DESCRIPTION
`python-coveralls` is unfortunately pinned to a really old version of `coverage`, which has been causing us problems with other builds. Here we switch to `coveralls`, which does not have this issue so as to use a newer version of `coverage` comfortably.