### PR TITLE
Fix Python versions used in CI environments

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -66,6 +66,9 @@ install:
     - cmd: conda create -y -n testenv
     - cmd: conda activate testenv
     - cmd: echo "python %PYVER%.*" >> %CONDA_PREFIX%\\conda-meta\\pinned
+    - cmd: echo "%CONDA_PREFIX%\\conda-meta"
+    - cmd: dir "%CONDA_PREFIX%\\conda-meta"
+    - cmd: type "%CONDA_PREFIX%\\conda-meta\\pinned"
     - cmd: conda env update -n testenv --file environment_ci.yml
 
 # Skip .NET project specific build phase.

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -65,7 +65,7 @@ install:
     # Create the test environment.
     - cmd: conda create -y -n testenv
     - cmd: conda activate testenv
-    - cmd: echo python %PYVER%.* >> %CONDA_PREFIX%\\conda-meta\\pinned
+    - cmd: echo python %PYVER%.*>> %CONDA_PREFIX%\\conda-meta\\pinned
     - cmd: echo "%CONDA_PREFIX%\\conda-meta"
     - cmd: dir "%CONDA_PREFIX%\\conda-meta"
     - cmd: type "%CONDA_PREFIX%\\conda-meta\\pinned"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -64,9 +64,10 @@ install:
     - cmd: conda config --get
 
     # Create the test environment.
-    - cmd: conda create -y -n testenv python="%CONDA_PY%"
-    - cmd: conda env update -n testenv --file environment_ci.yml
+    - cmd: conda create -y -n testenv
     - cmd: conda activate testenv
+    - cmd: echo "python %CONDA_PY%.*" >> "%CONDA_PREFIX%\\conda-meta\\pinned"
+    - cmd: conda env update -n testenv --file environment_ci.yml
 
 # Skip .NET project specific build phase.
 build: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -65,7 +65,7 @@ install:
     # Create the test environment.
     - cmd: conda create -y -n testenv
     - cmd: conda activate testenv
-    - cmd: echo "python %PYVER%.*" >> "%CONDA_PREFIX%\\conda-meta\\pinned"
+    - cmd: echo "python %PYVER%.*" >> %CONDA_PREFIX%\\conda-meta\\pinned
     - cmd: conda env update -n testenv --file environment_ci.yml
 
 # Skip .NET project specific build phase.

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -66,7 +66,7 @@ install:
     # Create the test environment.
     - cmd: conda create -y -n testenv python="%CONDA_PY%"
     - cmd: conda env update -n testenv --file environment_ci.yml
-    - cmd: activate testenv
+    - cmd: conda activate testenv
 
 # Skip .NET project specific build phase.
 build: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,10 +8,12 @@ environment:
     - TARGET_ARCH: x64
       CONDA_PY: 2.7
       CONDA_INSTALL_LOCN: C:\\Miniconda-x64
+      PYVER: 2.7
 
     - TARGET_ARCH: x64
       CONDA_PY: 3.7
       CONDA_INSTALL_LOCN: C:\\Miniconda37-x64
+      PYVER: 3.7
 
 
 # We always use a 64-bit machine, but can build x86 distributions
@@ -66,7 +68,7 @@ install:
     # Create the test environment.
     - cmd: conda create -y -n testenv
     - cmd: conda activate testenv
-    - cmd: echo "python %CONDA_PY%.*" >> "%CONDA_PREFIX%\\conda-meta\\pinned"
+    - cmd: echo "python %PYVER%.*" >> "%CONDA_PREFIX%\\conda-meta\\pinned"
     - cmd: conda env update -n testenv --file environment_ci.yml
 
 # Skip .NET project specific build phase.

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -66,9 +66,6 @@ install:
     - cmd: conda create -y -n testenv
     - cmd: conda activate testenv
     - cmd: echo python %PYVER%.*>> %CONDA_PREFIX%\\conda-meta\\pinned
-    - cmd: echo "%CONDA_PREFIX%\\conda-meta"
-    - cmd: dir "%CONDA_PREFIX%\\conda-meta"
-    - cmd: type "%CONDA_PREFIX%\\conda-meta\\pinned"
     - cmd: conda env update -n testenv --file environment_ci.yml
 
 # Skip .NET project specific build phase.

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -65,7 +65,7 @@ install:
     # Create the test environment.
     - cmd: conda create -y -n testenv
     - cmd: conda activate testenv
-    - cmd: echo "python %PYVER%.*" >> %CONDA_PREFIX%\\conda-meta\\pinned
+    - cmd: echo python %PYVER%.* >> %CONDA_PREFIX%\\conda-meta\\pinned
     - cmd: echo "%CONDA_PREFIX%\\conda-meta"
     - cmd: dir "%CONDA_PREFIX%\\conda-meta"
     - cmd: type "%CONDA_PREFIX%\\conda-meta\\pinned"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,8 +6,8 @@ environment:
 
   matrix:
     - TARGET_ARCH: x64
-      CONDA_PY: 2.7
-      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
+      CONDA_PY: 3.7
+      CONDA_INSTALL_LOCN: C:\\Miniconda37-x64
       PYVER: 2.7
 
     - TARGET_ARCH: x64

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,16 +4,13 @@ branches:
 
 environment:
 
-  matrix:
-    - TARGET_ARCH: x64
-      CONDA_PY: 3.7
-      CONDA_INSTALL_LOCN: C:\\Miniconda37-x64
-      PYVER: 2.7
+  TARGET_ARCH: x64
+  CONDA_PY: 3.7
+  CONDA_INSTALL_LOCN: C:\\Miniconda37-x64
 
-    - TARGET_ARCH: x64
-      CONDA_PY: 3.7
-      CONDA_INSTALL_LOCN: C:\\Miniconda37-x64
-      PYVER: 3.7
+  matrix:
+    - PYVER: 2.7
+    - PYVER: 3.7
 
 
 # We always use a 64-bit machine, but can build x86 distributions

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,7 @@ install:
 
   # Create the test environment.
   - conda create -y -n testenv python="${PYVER}"
-  - conda remove -y --force -n testenv openssl
   - conda env update -n testenv --file environment_ci.yml
-  - conda list --full-name -n testenv openssl || conda install -y -n testenv openssl
   - conda activate testenv
 
 # command to run tests, e.g. python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,8 @@ install:
   - openssl md5 miniconda.sh | grep e1045ee415162f944b6aebfe560b8fee
   - bash miniconda.sh -b -p ~/miniconda
   - rm miniconda.sh
-  - source ~/miniconda/bin/activate root
+  - source ~/miniconda/etc/profile.d/conda.sh
+  - conda activate
   - conda config --set show_channel_urls true
   - conda update -y -n root --all
   - conda install -y -n root conda-build
@@ -32,7 +33,7 @@ install:
   - conda remove -y --force -n testenv openssl
   - conda env update -n testenv --file environment_ci.yml
   - conda list --full-name -n testenv openssl || conda install -y -n testenv openssl
-  - source activate testenv
+  - conda activate testenv
 
 # command to run tests, e.g. python setup.py test
 script:
@@ -44,12 +45,12 @@ script:
 
 # Report coverage
 after_success:
-  - source activate root
+  - conda activate
   - conda create -y -n dplenv python="3.5";
   - conda remove -y --force -n dplenv openssl
   - conda env update -n dplenv --file environment_dpl.yml
   - conda list --full-name -n dplenv openssl || conda install -y -n dplenv openssl
-  - source activate dplenv
+  - conda activate dplenv
   - coveralls
 
 # Disable email notifications.

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,10 @@ install:
   - conda clean -tipsy
 
   # Create the test environment.
-  - conda create -y -n testenv python="${PYVER}"
-  - conda env update -n testenv --file environment_ci.yml
+  - conda create -y -n testenv
   - conda activate testenv
+  - echo "python ${PYVER}.*" >> "${CONDA_PREFIX}/conda-meta/pinned"
+  - conda env update -n testenv --file environment_ci.yml
 
 # command to run tests, e.g. python setup.py test
 script:

--- a/environment_ci.yml
+++ b/environment_ci.yml
@@ -4,8 +4,8 @@ channels:
   - conda-forge
 
 dependencies:
-  - pip==18.1
-  - wheel==0.32.2
-  - coverage==4.5.2
-  - pytest==3.10.1
-  - cython==0.29
+  - pip==18.0
+  - wheel==0.32.0
+  - coverage==4.5.1
+  - pytest==3.8.1
+  - cython==0.28.5


### PR DESCRIPTION
For some reason Travis CI builds were all using Python 3.7 instead of the specified Python version. This may be a change in how Conda solves these cases. So here we create an empty environment, activate it, and pin the Python version in that environment. That way updating it with the environment file afterwards has to keep the same Python version. Clean out the old `openssl` hack and use the new environment activation process while we are at it. Also fix the dependencies to versions that are available on Python 2.7 and 3.5-3.7.