### PR TITLE
Simplify buffer generation in `cybuffer`

### DIFF
--- a/src/cybuffer.pyx
+++ b/src/cybuffer.pyx
@@ -35,8 +35,6 @@ include "version.pxi"
 cdef extern from "Python.h":
     size_t Py_UNICODE_SIZE
 
-    object PyMemoryView_FromObject(object obj)
-
 
 cdef extern from *:
     """
@@ -147,8 +145,7 @@ cdef class cybuffer(object):
         else:
             raise TypeError("Unable to get buffer protocol API for `data`.")
 
-        # Create a buffer based on memoryview
-        data_buf = PyMemoryView_FromObject(data_buf)
+        # Fill out our buffer based on the data
         cpython.buffer.PyObject_GetBuffer(data_buf, &self._buf, PyBUF_FULL_RO)
 
         # Allocate and/or initialize metadata for casting
@@ -157,7 +154,7 @@ cdef class cybuffer(object):
         self._shape = self._buf.shape
         self._strides = self._buf.strides
 
-        # Figure out whether the memoryview is contiguous
+        # Figure out whether the data is contiguous
         self.c_contiguous = cpython.buffer.PyBuffer_IsContiguous(
             &self._buf, b'C'
         )

--- a/src/cybuffer.pyx
+++ b/src/cybuffer.pyx
@@ -133,15 +133,17 @@ cdef class cybuffer(object):
         self.obj = data
 
         cdef object data_buf
-        if cpython.buffer.PyObject_CheckBuffer(data):
-            data_buf = data
+        if cpython.buffer.PyObject_CheckBuffer(self.obj):
+            data_buf = self.obj
         elif PY2K:
             try:
                 data_buf = cpython.oldbuffer.PyBuffer_FromReadWriteObject(
-                    data, 0, -1
+                    self.obj, 0, -1
                 )
             except TypeError:
-                data_buf = cpython.oldbuffer.PyBuffer_FromObject(data, 0, -1)
+                data_buf = cpython.oldbuffer.PyBuffer_FromObject(
+                    self.obj, 0, -1
+                )
         else:
             raise TypeError("Unable to get buffer protocol API for `data`.")
 
@@ -167,9 +169,9 @@ cdef class cybuffer(object):
         # Workaround some special cases with the builtin array
         cdef size_t len_nd_b
         cdef int n_1
-        if isinstance(data, array):
+        if isinstance(self.obj, array):
             # Fix-up typecode
-            typecode = data.typecode
+            typecode = self.obj.typecode
             if typecode == "B":
                 return
             elif PY2K and typecode == "c":
@@ -185,7 +187,7 @@ cdef class cybuffer(object):
 
             # Adjust itemsize, shape, and strides based on casting
             if PY2K:
-                self.itemsize = data.itemsize
+                self.itemsize = self.obj.itemsize
 
                 len_nd_b = self._buf.ndim * sizeof(Py_ssize_t)
                 self._shape = <Py_ssize_t*>cpython.mem.PyMem_Malloc(len_nd_b)


### PR DESCRIPTION
Drops generation of a `memoryview` from our data. Using `PyObject_GetBuffer` is already sufficient for our needs and does essentially the same work. Helps us avoid an unneeded intermediate step and container. Plus it simplifies the code a bit.

Also only check to see if our data does not support the (new) buffer protocol on Python 2 for the purpose of trying to coerce it through the old buffer protocol. In all other cases, Python checks that the (new) buffer protocol is supported when calling `PyObject_GetBuffer`. If the (new) buffer protocol is not supported, it will raise an exception anyways. So there is no need for us to do this.