### PR TITLE
Simplify initialization of `cybuffer` with a builtin `array`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ else:
             "DEF PY2K = " + str(sys.version_info.major == 2) + "\n",
             "DEF PY3K = " + str(sys.version_info.major == 3) + "\n"
         ])
-        if sys.version_info.major < 4:
+        if sys.version_info.major < 4:  # pragma: no branch
             Py_UNICODE_SIZE = array.array('u').itemsize
             f.writelines([
                 "DEF Py_UNICODE_SIZE = " + str(Py_UNICODE_SIZE) + "\n",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import array
 import glob
 import os
 import sys
@@ -68,6 +69,12 @@ else:
             "DEF PY2K = " + str(sys.version_info.major == 2) + "\n",
             "DEF PY3K = " + str(sys.version_info.major == 3) + "\n"
         ])
+        if sys.version_info.major < 4:
+            Py_UNICODE_SIZE = array.array('u').itemsize
+            f.writelines([
+                "DEF Py_UNICODE_SIZE = " + str(Py_UNICODE_SIZE) + "\n",
+            ])
+
     with open("src/version.pxi", "w") as f:
         f.writelines([
             "__version__ = " + "\"" + str(version) + "\""

--- a/src/cybuffer.pyx
+++ b/src/cybuffer.pyx
@@ -163,16 +163,14 @@ cdef class cybuffer(object):
         if (PY2K or PY3K) and isinstance(self.obj, array):
             # Fix-up typecode
             typecode = self.obj.typecode
-            if typecode == "B" or (PY2K and typecode == "c"):
-                return
-            elif typecode == "u":
+            if typecode == "u":
                 if PY2K:
                     self.itemsize = Py_UNICODE_SIZE
                 if Py_UNICODE_SIZE == 2:
                     self._format = UCS2_TC
                 elif Py_UNICODE_SIZE == 4:
                     self._format = UCS4_TC
-            elif PY2K:
+            elif PY2K and typecode not in "Bc":
                 self.itemsize = self.obj.itemsize
                 self._format = typecode
 

--- a/src/cybuffer.pyx
+++ b/src/cybuffer.pyx
@@ -162,7 +162,7 @@ cdef class cybuffer(object):
         # Workaround some special cases with the builtin array
         cdef size_t len_nd_b
         cdef int n_1
-        if isinstance(self.obj, array):
+        if (PY2K or PY3K) and isinstance(self.obj, array):
             # Fix-up typecode
             typecode = self.obj.typecode
             if typecode == "B":
@@ -170,7 +170,7 @@ cdef class cybuffer(object):
             elif PY2K and typecode == "c":
                 self._format = UBYTE_TC
                 return
-            elif (PY2K or PY3K) and typecode == "u":
+            elif typecode == "u":
                 if Py_UNICODE_SIZE == 2:
                     self._format = UCS2_TC
                 elif Py_UNICODE_SIZE == 4:

--- a/src/cybuffer.pyx
+++ b/src/cybuffer.pyx
@@ -177,7 +177,7 @@ cdef class cybuffer(object):
                 self._format = typecode
 
             # Adjust shape and strides based on casting
-            if PY2K:
+            if PY2K and self.itemsize != 1:
                 len_nd_b = self._buf.ndim * sizeof(Py_ssize_t)
                 self._shape = <Py_ssize_t*>cpython.mem.PyMem_Malloc(len_nd_b)
                 self._strides = <Py_ssize_t*>cpython.mem.PyMem_Malloc(len_nd_b)

--- a/src/cybuffer.pyx
+++ b/src/cybuffer.pyx
@@ -163,9 +163,7 @@ cdef class cybuffer(object):
         if (PY2K or PY3K) and isinstance(self.obj, array):
             # Fix-up typecode
             typecode = self.obj.typecode
-            if typecode == "B":
-                return
-            elif PY2K and typecode == "c":
+            if typecode == "B" or (PY2K and typecode == "c"):
                 return
             elif typecode == "u":
                 if Py_UNICODE_SIZE == 2:

--- a/src/cybuffer.pyx
+++ b/src/cybuffer.pyx
@@ -166,17 +166,18 @@ cdef class cybuffer(object):
             if typecode == "B" or (PY2K and typecode == "c"):
                 return
             elif typecode == "u":
+                if PY2K:
+                    self.itemsize = Py_UNICODE_SIZE
                 if Py_UNICODE_SIZE == 2:
                     self._format = UCS2_TC
                 elif Py_UNICODE_SIZE == 4:
                     self._format = UCS4_TC
             elif PY2K:
+                self.itemsize = self.obj.itemsize
                 self._format = typecode
 
-            # Adjust itemsize, shape, and strides based on casting
+            # Adjust shape and strides based on casting
             if PY2K:
-                self.itemsize = self.obj.itemsize
-
                 len_nd_b = self._buf.ndim * sizeof(Py_ssize_t)
                 self._shape = <Py_ssize_t*>cpython.mem.PyMem_Malloc(len_nd_b)
                 self._strides = <Py_ssize_t*>cpython.mem.PyMem_Malloc(len_nd_b)

--- a/src/cybuffer.pyx
+++ b/src/cybuffer.pyx
@@ -161,7 +161,7 @@ cdef class cybuffer(object):
         cdef size_t len_nd_b
         cdef int n_1
         if (PY2K or PY3K) and isinstance(self.obj, array):
-            # Fix-up typecode
+            # Cast to appropriate format with given itemsize
             typecode = self.obj.typecode
             if typecode == "u":
                 if PY2K:

--- a/src/cybuffer.pyx
+++ b/src/cybuffer.pyx
@@ -33,8 +33,6 @@ include "version.pxi"
 
 
 cdef extern from "Python.h":
-    size_t Py_UNICODE_SIZE
-
     object PyMemoryView_FromObject(object obj)
 
 

--- a/src/cybuffer.pyx
+++ b/src/cybuffer.pyx
@@ -166,7 +166,6 @@ cdef class cybuffer(object):
             if typecode == "B":
                 return
             elif PY2K and typecode == "c":
-                self._format = UBYTE_TC
                 return
             elif typecode == "u":
                 if Py_UNICODE_SIZE == 2:


### PR DESCRIPTION
Makes some small adjustments to how `cybuffer` handles the `array` initialization case. Namely only special case handling of `array` on Python 3 or earlier (as Python 4 shouldn't have any of these issues). Also turn `Py_UNICODE_SIZE` into a Cython compile-time constant to cutdown on C code generated in relation to it. Finally cleanup and fuse together some no-op cases for some `array` types. Streamlines things a bit and makes it a bit clearer what is happening in the code.