### PR TITLE
Drop `UBYTE_TC`

### DIFF
--- a/src/cybuffer.pyx
+++ b/src/cybuffer.pyx
@@ -38,7 +38,6 @@ cdef extern from "Python.h":
 
 cdef extern from *:
     """
-    #define UBYTE_TC "B"
     #define UCS2_TC "H"
     #define UCS4_TC "I"
 
@@ -48,7 +47,6 @@ cdef extern from *:
             Py_INCREF(o); PyTuple_SET_ITEM(l, i, o)
     """
 
-    char* UBYTE_TC
     char* UCS2_TC
     char* UCS4_TC
 


### PR DESCRIPTION
Follow-up to PR ( https://github.com/jakirkham/cybuffer/pull/13 )

As `UBYTE_TC` is no longer used thanks to improvement in array initialization, go ahead drop its definition.