### PR TITLE
Simplify `array`'s shape and strides adjustment

### DIFF
--- a/src/cybuffer.pyx
+++ b/src/cybuffer.pyx
@@ -157,7 +157,6 @@ cdef class cybuffer(object):
 
         # Workaround some special cases with the builtin array
         cdef size_t len_nd_b
-        cdef int n_1
         if (PY2K or PY3K) and isinstance(self.obj, array):
             # Cast to appropriate format with given itemsize
             typecode = self.obj.typecode
@@ -178,9 +177,8 @@ cdef class cybuffer(object):
                 self._shape = <Py_ssize_t*>cpython.mem.PyMem_Malloc(len_nd_b)
                 self._strides = <Py_ssize_t*>cpython.mem.PyMem_Malloc(len_nd_b)
 
-                n_1 = self._buf.ndim - 1
-                self._shape[n_1] = self._buf.shape[n_1] // self.itemsize
-                self._strides[n_1] = self._buf.strides[n_1] * self.itemsize
+                self._shape[0] = self._buf.shape[0] // self.itemsize
+                self._strides[0] = self._buf.strides[0] * self.itemsize
 
 
     def __dealloc__(self):

--- a/src/cybuffer.pyx
+++ b/src/cybuffer.pyx
@@ -173,7 +173,7 @@ cdef class cybuffer(object):
 
             # Adjust shape and strides based on casting
             if PY2K and self.itemsize != 1:
-                len_nd_b = self._buf.ndim * sizeof(Py_ssize_t)
+                len_nd_b = sizeof(Py_ssize_t)
                 self._shape = <Py_ssize_t*>cpython.mem.PyMem_Malloc(len_nd_b)
                 self._strides = <Py_ssize_t*>cpython.mem.PyMem_Malloc(len_nd_b)
 


### PR DESCRIPTION
When adjusting the `shape` and `strides` to take into account Python 2's `array`'s recasting of type, simplify the code a bit knowing the Python 2 `array` must be 1-D. As such there is no need to find the last dimension. Instead just update the `shape` and `strides` at index `0` as that is the first and last dimension. This simplifies the code a bit, improves C code generated from it, and clarifies the code's intent.