### PR TITLE
Handle array format fixes with C strings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,11 +69,6 @@ else:
             "DEF PY2K = " + str(sys.version_info.major == 2) + "\n",
             "DEF PY3K = " + str(sys.version_info.major == 3) + "\n"
         ])
-        if sys.version_info.major < 4:  # pragma: no branch
-            Py_UNICODE_SIZE = array.array('u').itemsize
-            f.writelines([
-                "DEF Py_UNICODE_SIZE = " + str(Py_UNICODE_SIZE) + "\n",
-            ])
 
     with open("src/version.pxi", "w") as f:
         f.writelines([

--- a/src/cybuffer.pyx
+++ b/src/cybuffer.pyx
@@ -38,8 +38,8 @@ cdef extern from "Python.h":
 
 cdef extern from *:
     """
-    #define UCS2_TC "H"
-    #define UCS4_TC "I"
+    #define UINT16_TC "H"
+    #define UINT32_TC "I"
 
     #define PyList_SET_ITEM_INC(l, i, o)  \
             Py_INCREF(o); PyList_SET_ITEM(l, i, o)
@@ -47,8 +47,8 @@ cdef extern from *:
             Py_INCREF(o); PyTuple_SET_ITEM(l, i, o)
     """
 
-    char* UCS2_TC
-    char* UCS4_TC
+    char* UINT16_TC
+    char* UINT32_TC
 
     void PyList_SET_ITEM_INC(object, Py_ssize_t, object)
     void PyTuple_SET_ITEM_INC(object, Py_ssize_t, object)
@@ -183,9 +183,9 @@ cdef class cybuffer(object):
                 if PY2K:
                     self.itemsize = Py_UNICODE_SIZE
                 if Py_UNICODE_SIZE == 2:
-                    self._format = UCS2_TC
+                    self._format = UINT16_TC
                 elif Py_UNICODE_SIZE == 4:
-                    self._format = UCS4_TC
+                    self._format = UINT32_TC
             elif PY2K and typecode not in "Bc":
                 self.itemsize = self.obj.itemsize
                 self._format = typecode

--- a/src/cybuffer.pyx
+++ b/src/cybuffer.pyx
@@ -4,6 +4,7 @@ cimport cybuffer
 
 cimport libc
 cimport libc.string
+from libc.string cimport strcmp
 
 cimport cython
 cimport cython.view
@@ -196,11 +197,11 @@ cdef class cybuffer(object):
                 self._format = self.obj.typecode
 
             # Cast to appropriate format
-            if libc.string.strcmp(self._format, UCS2_TC) == 0:
+            if strcmp(self._format, UCS2_TC) == 0:
                 self._format = UINT16_TC
-            elif libc.string.strcmp(self._format, UCS4_TC) == 0:
+            elif strcmp(self._format, UCS4_TC) == 0:
                 self._format = UINT32_TC
-            elif PY2K and libc.string.strcmp(self._format, CHAR_TC) == 0:
+            elif PY2K and strcmp(self._format, CHAR_TC) == 0:
                 self._format = UINT8_TC
 
             # Adjust shape and strides based on casting

--- a/src/cybuffer.pyx
+++ b/src/cybuffer.pyx
@@ -42,10 +42,6 @@ cdef extern from "Python.h":
 
 cdef extern from *:
     """
-    #define CHAR_TC "c"
-    #define UCS2_TC "u"
-    #define UCS4_TC "w"
-
     #define UINT8_TC "B"
     #define UINT16_TC "H"
     #define UINT32_TC "I"
@@ -55,10 +51,6 @@ cdef extern from *:
     #define PyTuple_SET_ITEM_INC(l, i, o)  \
             Py_INCREF(o); PyTuple_SET_ITEM(l, i, o)
     """
-
-    char* CHAR_TC
-    char* UCS2_TC
-    char* UCS4_TC
 
     char* UINT8_TC
     char* UINT16_TC
@@ -197,11 +189,13 @@ cdef class cybuffer(object):
                 self._format = self.obj.typecode
 
             # Cast to appropriate format
-            if strcmp(self._format, UCS2_TC) == 0:
-                self._format = UINT16_TC
-            elif strcmp(self._format, UCS4_TC) == 0:
-                self._format = UINT32_TC
-            elif PY2K and strcmp(self._format, CHAR_TC) == 0:
+            if (strcmp(self._format, "u") == 0 or
+                strcmp(self._format, "w") == 0):
+                if self.itemsize == 2:
+                    self._format = UINT16_TC
+                elif self.itemsize == 4:
+                    self._format = UINT32_TC
+            elif PY2K and strcmp(self._format, "c") == 0:
                 self._format = UINT8_TC
 
             # Adjust shape and strides based on casting

--- a/src/cybuffer.pyx
+++ b/src/cybuffer.pyx
@@ -186,7 +186,7 @@ cdef class cybuffer(object):
                 self.itemsize = self.obj.itemsize
                 self._format = self.obj.typecode
 
-            # Cast to appropriate format
+            # Recast text formats
             fmt = self._format[0]
             if PY2K and fmt == 'c':
                 self._format = UINT8_TC

--- a/src/cybuffer.pyx
+++ b/src/cybuffer.pyx
@@ -2,10 +2,6 @@ include "config.pxi"
 
 cimport cybuffer
 
-cimport libc
-cimport libc.string
-from libc.string cimport strcmp
-
 cimport cython
 cimport cython.view
 
@@ -182,6 +178,8 @@ cdef class cybuffer(object):
         self.contiguous = self.c_contiguous or self.f_contiguous
 
         # Workaround some special cases with the builtin array
+        IF PY2K or PY3K:
+            cdef char fmt
         if (PY2K or PY3K) and isinstance(self.obj, array):
             # Correct itemsize and format on Python 2
             if PY2K:
@@ -189,13 +187,13 @@ cdef class cybuffer(object):
                 self._format = self.obj.typecode
 
             # Cast to appropriate format
-            if (strcmp(self._format, "u") == 0 or
-                strcmp(self._format, "w") == 0):
+            fmt = self._format[0]
+            if fmt == 'u' or fmt == 'w':
                 if self.itemsize == 2:
                     self._format = UINT16_TC
                 elif self.itemsize == 4:
                     self._format = UINT32_TC
-            elif PY2K and strcmp(self._format, "c") == 0:
+            elif PY2K and fmt == 'c':
                 self._format = UINT8_TC
 
             # Adjust shape and strides based on casting

--- a/src/cybuffer.pyx
+++ b/src/cybuffer.pyx
@@ -41,13 +41,13 @@ cdef extern from "Python.h":
 
 cdef extern from *:
     """
-    #define UINT8_TC "B"
-    #define UINT16_TC "H"
-    #define UINT32_TC "I"
-
     #define CHAR_TC "c"
     #define UCS2_TC "u"
     #define UCS4_TC "w"
+
+    #define UINT8_TC "B"
+    #define UINT16_TC "H"
+    #define UINT32_TC "I"
 
     #define PyList_SET_ITEM_INC(l, i, o)  \
             Py_INCREF(o); PyList_SET_ITEM(l, i, o)
@@ -55,13 +55,13 @@ cdef extern from *:
             Py_INCREF(o); PyTuple_SET_ITEM(l, i, o)
     """
 
-    char* UINT8_TC
-    char* UINT16_TC
-    char* UINT32_TC
-
     char* CHAR_TC
     char* UCS2_TC
     char* UCS4_TC
+
+    char* UINT8_TC
+    char* UINT16_TC
+    char* UINT32_TC
 
     void PyList_SET_ITEM_INC(object, Py_ssize_t, object)
     void PyTuple_SET_ITEM_INC(object, Py_ssize_t, object)

--- a/src/cybuffer.pyx
+++ b/src/cybuffer.pyx
@@ -188,13 +188,13 @@ cdef class cybuffer(object):
 
             # Cast to appropriate format
             fmt = self._format[0]
-            if fmt == 'u' or fmt == 'w':
+            if PY2K and fmt == 'c':
+                self._format = UINT8_TC
+            elif fmt == 'u' or fmt == 'w':
                 if self.itemsize == 2:
                     self._format = UINT16_TC
                 elif self.itemsize == 4:
                     self._format = UINT32_TC
-            elif PY2K and fmt == 'c':
-                self._format = UINT8_TC
 
             # Adjust shape and strides based on casting
             if PY2K and self.itemsize != 1:


### PR DESCRIPTION
Copies over `format` and `itemsize` information for Python 2 to start with. This largely removes the differences between Python 2/3 `array` format handling (with the exception of Python 2 only formats). Then handle format checks with C strings for all cases. As the strings should all by one `char` long in our case. Simply compare the `char` values directly.

As unicode `array`s are represented with either a `"u"` or `"w"` format to indicate UCS2 or UCS4, check both of these independently at runtime. This drops the use of `Py_UNICODE_SIZE` in the code, which should make binaries a bit more portable as they are not dependent on the underlying unicode character size.

Checks for the Python 2 character array format case `"c"` explicitly. This was handled implicitly before as the Python 2 code path through the old buffer protocol casting everything to the unsigned bytes format `"B"`. However now it needs to be handled explicitly as we want to have our data treated as unsigned bytes instead of the legacy character format.

All other cases simply leverage whatever the `array` exported either through the buffer protocol on Python 3 or what we patched in afterwards from the `array`'s information on Python 2. This makes it a little clearer what the unusual cases are that need patching (i.e. unicode and character arrays). Also it makes it a little clearer that on Python 2 we are pulling this information from the `array`. Appears to improve performance as well. Not to mention binaries are a bit more portable.