### PR TITLE
Ensure empty `shape` or `strides` return `tuple`s

### DIFF
--- a/src/cybuffer.pyx
+++ b/src/cybuffer.pyx
@@ -249,31 +249,17 @@ cdef class cybuffer(object):
 
     @property
     def shape(self):
-        if self._shape is NULL:
-            r = tuple()
-        else:
-            r = pointer_to_tuple(self._buf.ndim, self._shape)
-        return r
+        return pointer_to_tuple(self._buf.ndim, self._shape)
 
 
     @property
     def strides(self):
-        cdef tuple r
-        if self._strides is NULL:
-            r = tuple()
-        else:
-            r = pointer_to_tuple(self._buf.ndim, self._strides)
-        return r
+        return pointer_to_tuple(self._buf.ndim, self._strides)
 
 
     @property
     def suboffsets(self):
-        cdef tuple r
-        if self._buf.suboffsets is NULL:
-            r = tuple()
-        else:
-            r = pointer_to_tuple(self._buf.ndim, self._buf.suboffsets)
-        return r
+        return pointer_to_tuple(self._buf.ndim, self._buf.suboffsets)
 
 
     def __len__(self):

--- a/src/cybuffer.pyx
+++ b/src/cybuffer.pyx
@@ -246,12 +246,21 @@ cdef class cybuffer(object):
 
     @property
     def shape(self):
-        return pointer_to_tuple(self._buf.ndim, self._shape)
+        if self._shape is NULL:
+            r = tuple()
+        else:
+            r = pointer_to_tuple(self._buf.ndim, self._shape)
+        return r
 
 
     @property
     def strides(self):
-        return pointer_to_tuple(self._buf.ndim, self._strides)
+        cdef tuple r
+        if self._strides is NULL:
+            r = tuple()
+        else:
+            r = pointer_to_tuple(self._buf.ndim, self._strides)
+        return r
 
 
     @property

--- a/src/cybuffer.pyx
+++ b/src/cybuffer.pyx
@@ -86,6 +86,9 @@ cdef tuple pointer_to_tuple(int n, Py_ssize_t* p):
     cdef object p_i
     cdef tuple result
 
+    if p is NULL:
+        n = 0
+
     result = cpython.tuple.PyTuple_New(n)
     for i in range(n):
         p_i = long(p[i])


### PR DESCRIPTION
This is inline with the behavior of `suboffsets` currently. Also matches with the behavior of `memoryview` in Python 3.